### PR TITLE
Adding support for mode signal during Primetime

### DIFF
--- a/coffe/utils.py
+++ b/coffe/utils.py
@@ -883,6 +883,8 @@ def load_hard_params(filename):
             hard_params['primetime_folder'] = value
         elif param == 'core_site_name':
             hard_params['core_site_name'] = value
+        elif param == 'mode_signal':
+            hard_params['mode_signal'].append(value)
 
     hard_file.close()
     return hard_params


### PR DESCRIPTION
Dr. Betz, 

I was doing some COFFE experiments and I saw that providing a value to "mode_signal" configuration variable in the hardblock settings file was not working. I saw that that was because a missing couple of lines in utils.py. 

This is how it was in the original COFFE code, before my changes from last month. My guess is that it was like this because this feature isn't getting tested in any of the existing tests because in the hbsettings.txt file, the mode_signal is commented out (https://github.com/vaughnbetz/COFFE/blob/master/input_files/hbsettings.txt#L136).

Anyway, I fixed it locally and I tested it and it works now. I thought I'll submit a push request for this.

Thanks,
Aman