### PR TITLE
Added a factor of 2 for RAM_wordlinedriver_area in fpga.py, line 5768 since there are 2 wordlines (1 for each port) per BRAM row. 

### DIFF
--- a/coffe/fpga.py
+++ b/coffe/fpga.py
@@ -5765,7 +5765,8 @@ class FPGA:
             RAM_area += self.area_dict[self.RAM.pgateoutputcrossbar.name + "_sram"] 
             # add the wordline drivers:
             RAM_wordlinedriver_area = self.area_dict[self.RAM.wordlinedriver.name] * self.number_of_banks
-            RAM_wordlinedriver_area = RAM_wordlinedriver_area * 2 # We have 2 wordline drivers per row
+            # we need 2 wordline drivers per row, since there are 2 wordlines in each row to control 2 BRAM ports, respectively
+            RAM_wordlinedriver_area = RAM_wordlinedriver_area * 2 
             RAM_area += self.area_dict["level_shifters"]
             RAM_area += RAM_wordlinedriver_area
 

--- a/coffe/fpga.py
+++ b/coffe/fpga.py
@@ -5766,7 +5766,7 @@ class FPGA:
             # add the wordline drivers:
             RAM_wordlinedriver_area = self.area_dict[self.RAM.wordlinedriver.name] * self.number_of_banks
             RAM_area += self.area_dict["level_shifters"]
-            RAM_area += RAM_wordlinedriver_area
+            RAM_area += 2 * RAM_wordlinedriver_area
 
             # write into dictionaries:
             self.area_dict["wordline_total"] = RAM_wordlinedriver_area

--- a/coffe/fpga.py
+++ b/coffe/fpga.py
@@ -5765,8 +5765,9 @@ class FPGA:
             RAM_area += self.area_dict[self.RAM.pgateoutputcrossbar.name + "_sram"] 
             # add the wordline drivers:
             RAM_wordlinedriver_area = self.area_dict[self.RAM.wordlinedriver.name] * self.number_of_banks
+            RAM_wordlinedriver_area = RAM_wordlinedriver_area * 2 # We have 2 wordline drivers per row
             RAM_area += self.area_dict["level_shifters"]
-            RAM_area += 2 * RAM_wordlinedriver_area
+            RAM_area += RAM_wordlinedriver_area
 
             # write into dictionaries:
             self.area_dict["wordline_total"] = RAM_wordlinedriver_area


### PR DESCRIPTION
Modification based on issue #36 